### PR TITLE
Temp fix xarray repr dark mode (pydata theme)

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -12,3 +12,11 @@
 .gp {
   color: darkorange;
 }
+
+/* workaround Pydata Sphinx theme using light colors for widget cell outputs in dark-mode */
+/* works for many widgets but not for Xarray html reprs */
+/* https://github.com/pydata/pydata-sphinx-theme/issues/2189 */
+html[data-theme="dark"] div.cell_output .text_html:has(div.xr-wrap) {
+  background-color: var(--pst-color-on-background) !important;
+  color: var(--pst-color-text-base) !important;
+}


### PR DESCRIPTION
Main branch:

<img width="791" alt="Screenshot 2025-07-07 at 10 28 34" src="https://github.com/user-attachments/assets/914e97f4-7386-4bc2-a1d9-94e24de9abb8" />

This PR:

<img width="796" alt="Screenshot 2025-07-07 at 10 28 04" src="https://github.com/user-attachments/assets/eb51c3b2-5fba-4521-b619-f0ba2762084e" />
