### PR TITLE
Add more descriptive headings

### DIFF
--- a/docs/agnostic/pint.md
+++ b/docs/agnostic/pint.md
@@ -7,7 +7,7 @@ kernelspec:
   name: python
 ---
 
-# pint-xarray: PintIndex
+# Units with `pint_xarray.PintIndex`
 
 ````{grid}
 ```{grid-item}

--- a/docs/blocks/ndpoint.md
+++ b/docs/blocks/ndpoint.md
@@ -1,1 +1,1 @@
-# NDPointIndex
+# Tree-based indexes with `NDPointIndex`

--- a/docs/blocks/transform.md
+++ b/docs/blocks/transform.md
@@ -1,1 +1,1 @@
-# CoordinateTransformIndex
+# Functional transformations with `CoordinateTransformIndex`

--- a/docs/builtin/pdinterval.md
+++ b/docs/builtin/pdinterval.md
@@ -7,7 +7,7 @@ kernelspec:
   name: python
 ---
 
-# pandas: IntervalIndex
+# Intervals with `pandas.IntervalIndex`
 
 ````{grid}
 ```{grid-item}

--- a/docs/builtin/range.md
+++ b/docs/builtin/range.md
@@ -1,1 +1,1 @@
-# RangeIndex
+# Large ranges with `RangeIndex`

--- a/docs/earth/forecast.md
+++ b/docs/earth/forecast.md
@@ -7,7 +7,7 @@ kernelspec:
   name: python
 ---
 
-# rolodex: Weather Forecasts
+# Weather forecast cubes with `rolodex.ForecastIndex`
 
 ```{seealso}
 Learn more at the [rolodex](https://rolodex.readthedocs.io) documentation.

--- a/docs/earth/raster.md
+++ b/docs/earth/raster.md
@@ -7,7 +7,7 @@ kernelspec:
   name: python
 ---
 
-# rasterix: RasterIndex
+# Raster affine transforms with `rasterix.RasterIndex`
 
 ````{grid}
 ```{grid-item}

--- a/docs/earth/xdggs.md
+++ b/docs/earth/xdggs.md
@@ -7,7 +7,7 @@ kernelspec:
   name: python
 ---
 
-# xdggs: DGGSIndex
+# Discrete Global Grid Systems with `xdggs.DGGSIndex`
 
 ````{grid}
 ```{grid-item}

--- a/docs/earth/xproj.md
+++ b/docs/earth/xproj.md
@@ -7,7 +7,7 @@ kernelspec:
   name: python
 ---
 
-# xproj: CRSIndex
+# Coordinate Reference Systems with `xproj.CRSIndex`
 
 ```{seealso}
 Learn more at the [xproj](https://xproj.readthedocs.io) documentation

--- a/docs/earth/xvec.md
+++ b/docs/earth/xvec.md
@@ -7,7 +7,7 @@ kernelspec:
   name: python
 ---
 
-# xvec: GeometryIndex
+# Geometries and Vector Data Cubes with `xvec.GeometryIndex`
 
 ````{grid} 12
 ```{grid-item}


### PR DESCRIPTION
This is an experiment with more verbose headings to make it easy for users to browse through, and understand what they might find. Happy to take suggestions. One consideration is that rendering long headings might be ugly, but I feel the increased ease-of-use is worth it. We should definitely be _very_ concise.

I kept the "class name" in the headings because we may have duplicates for example, "Intervals with `pd.IntervalIndex`" and `Intervals with `CFIntervalIndex`"