### PR TITLE
Tweak sidebar headings a bit.

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -3,6 +3,11 @@
   height: 150px;
 }
 
+code.literal {
+  background-color: unset;
+  border: unset;
+}
+
 .xr-wrap {
   /* workaround when (ipy)widgets are present in output cells
    * https://github.com/xarray-contrib/xarray-indexes/issues/14


### PR DESCRIPTION
Makes it a little less busy:

**Before**

<img width="284" alt="image" src="https://github.com/user-attachments/assets/9dac1212-a249-4b7b-9352-b10ef6312d09" />

**After**

<img width="284" alt="image" src="https://github.com/user-attachments/assets/2d1c8efa-03b3-441d-8192-f30b7b647f87" />


Also affects inline code like this:
**Before**

<img width="332" alt="image" src="https://github.com/user-attachments/assets/62e82893-fe00-4a69-aa1e-971d641f2142" />


**After**
<img width="332" alt="image" src="https://github.com/user-attachments/assets/d239d9eb-d724-4428-b265-3a615adce8dc" />


But I like that too
